### PR TITLE
Removed database specification from tests.

### DIFF
--- a/t/02-queue.t
+++ b/t/02-queue.t
@@ -29,7 +29,7 @@ ok($dbh->do('create table q4m_t (v int not null) engine=queue'));
 
 for (my $i = 0; $i < $TEST_ROWS; $i++) {
     ok($dbh->do("insert into q4m_t (v) values ($i)"));
-    ok($dbh->do("select queue_wait('test.q4m_t')"));
+    ok($dbh->do("select queue_wait('q4m_t')"));
     is_deeply(
         $dbh->selectall_arrayref('select * from q4m_t'),
         [ [ $i ] ],

--- a/t/03-queue-error-wait.t
+++ b/t/03-queue-error-wait.t
@@ -16,7 +16,7 @@ my $dbh = DBI->connect(
 ok($dbh->do('drop table if exists q4m_t'));
 ok($dbh->do('create table q4m_t (v int not null) engine=queue'));
 
-ok($dbh->do("select queue_wait('test.q4m_t', 1)"));
+ok($dbh->do("select queue_wait('q4m_t', 1)"));
 is_deeply(
     $dbh->selectall_arrayref("select * from q4m_t"),
     [],
@@ -31,12 +31,12 @@ is_deeply(
     $dbh->selectall_arrayref("select * from q4m_t"),
     [ [ 1 ] ],
 );
-ok($dbh->do("select queue_wait('test.q4m_t', 1)"));
+ok($dbh->do("select queue_wait('q4m_t', 1)"));
 is_deeply(
     $dbh->selectall_arrayref("select * from q4m_t"),
     [ [ 1 ] ],
 );
-ok($dbh->do("select queue_wait('test.q4m_t', 1)"));
+ok($dbh->do("select queue_wait('q4m_t', 1)"));
 is_deeply(
     $dbh->selectall_arrayref("select * from q4m_t"),
     [],

--- a/t/03-queue-error.t
+++ b/t/03-queue-error.t
@@ -23,7 +23,7 @@ ok($dbh->do('create table q4m_t (v int not null) engine=queue'));
 
 ok($dbh->do("insert into q4m_t (v) values (1),(2)"));
 is_deeply(
-    [ $dbh2->selectrow_array("select queue_wait('test.q4m_t')") ],
+    [ $dbh2->selectrow_array("select queue_wait('q4m_t')") ],
     [ 1 ],
 );
 is_deeply(
@@ -44,7 +44,7 @@ is_deeply(
     [ [ 1 ], [ 2 ] ],
 );
 
-ok($dbh2->do("select queue_wait('test.q4m_t')"));
+ok($dbh2->do("select queue_wait('q4m_t')"));
 is_deeply(
     $dbh2->selectall_arrayref("select * from q4m_t"),
     [ [ 1 ] ],
@@ -65,7 +65,7 @@ $dbh2->disconnect;
 my $pid = fork;
 if ($pid == 0) {
     $dbh = dbi_connect();
-    $dbh->do("select queue_wait('test.q4m_t')");
+    $dbh->do("select queue_wait('q4m_t')");
     sleep 10;
     die "shouldn't reach here\n";
 }


### PR DESCRIPTION
Previously tests failed when users specify database name with DBI environmental variable
since some test codes explicitly had `test' as database name.

$ # Here using `q4m_test'. Now this works if q4m_test database is already created.
$ DBI='dbi:mysql:database=q4m_test;host=localhost'  DBI_USER='root' DBI_PASSWORD='' make test
