### PR TITLE
Add log for `pthread_create` failure

### DIFF
--- a/src/ha_queue.cc
+++ b/src/ha_queue.cc
@@ -803,6 +803,7 @@ queue_share_t *queue_share_t::get_share(const char *table_name, bool if_is_open)
   /* start threads */
   share->writer_do_wake_listeners = false;
   if (pthread_create(&share->writer_thread, NULL, _writer_start, share) != 0) {
+    log("Can't create a thread to handle Q4M: %s\n", table_name);
     goto ERR_AFTER_MMAP;
   }
   /* add to open_tables */


### PR DESCRIPTION
Q4M needs to create a pthread for each table. When there is a large number of Q4M tables, corresponding large number of threads are created, and the number of threads sometimes reaches the limit of supervising systems such as systemd.

In this situation, `pthread_create` fails, and Q4M eventually returns the `HA_ERR_CRASHED_ON_USAGE` by the following code.

https://github.com/q4m/q4m/blob/6cbd1bb1fbaf06c7df6d66fcc9c1eaac5669996a/src/ha_queue.cc#L2314-L2316

c.f. https://man7.org/linux/man-pages/man3/pthread_create.3.html

IMHO, the issue here is the description of the error message.

```
mysql> select * from q4m_test.sample_table;
ERROR 1194 (HY000): Table 'sample_table' is marked as crashed and should be repaired
```

When people see the above message, they tend to search for solutions such as `REPAIR TABLE`, even though the actual cause is the failure of `pthread_create`. In order to improve understandability, I have added the log for `pthread_create` failure. Following are the log I had on a container on my local Mac.

```
220426 02:19:54 ha_queue: /usr/local/mysql-build/build/mysql-5.7.20/storage/q4m/src/ha_queue.cc:806: Can't create a thread to handle Q4M: ./q4m_test/sample_table
```

IMHO, this message shortens the time for developers to solve the root cause.

--------

I have checked that the `log` is working as intended with MySQL 5.7.20 on Ubuntu with Docker Desktop for Mac.
Also, I have obfuscated some work-related information in the above log.

Regarding MySQL 8, I am now struggling to build MySQL from source code with Q4M......
(Updated: I have successfully installed it.)
