### PR TITLE
Add `cpanfile` for easy testing

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,12 @@
+requires 'Time::HiRes';
+requires 'List::Util';
+requires 'List::MoreUtils';
+requires 'Data::Compare';
+requires 'Parallel::ForkManager';
+
+requires 'DBI';
+requires 'DBD::mysql';
+
+requires 'Test::Harness';
+requires 'Test::More';
+requires 'Test::mysqld';


### PR DESCRIPTION
I would like to add `cpanfile` for easy testing.

This allows developers to install all the required Perl modules to run `run_tests.pl`.
For simplicity, I specified the package names only.

As testing is documented [here](http://mogile.web.fc2.com/q4m/install.html), I avoided touching documentation in this Pull Request.

I have used this file with Carton.